### PR TITLE
Updated sessionList.tsx to sort sessions by name

### DIFF
--- a/src/components/sessionList.tsx
+++ b/src/components/sessionList.tsx
@@ -18,7 +18,7 @@ export class SessionList extends React.Component<ICardListProps> {
 
         return (
             <ul className="session-list">
-                {sessions.map(session => (
+                {sessions.sort((a, b) => a.session.name > b.session.name ? 1 : -1).map(session => (
                     <SessionCard
                         key={session.session.id}
                         session={session}


### PR DESCRIPTION
Updated sessionList.tsx to sort sessions by name to address #215 

Note the id of session2 in the URL in the bottom left corner of both screenshots to confirm change is working as expected.

Before:
![image](https://user-images.githubusercontent.com/32421665/216455715-0deaa073-9f60-4a3e-80f8-00fb023e9e67.png)

After:
![image](https://user-images.githubusercontent.com/32421665/216455611-7c73f0dc-dba0-4689-91d5-bcf08e9b6fc4.png)