### PR TITLE
Expand doubling strategy to 128 AB Fixes #347

### DIFF
--- a/src/model/cards.ts
+++ b/src/model/cards.ts
@@ -366,6 +366,18 @@ export const defaultCardSets: ICardSet[] = [
         value: 16,
       },
       {
+        identifier: "32",
+        value: 32,
+      },
+      {
+        identifier: "64",
+        value: 64,
+      },
+      {
+        identifier: "128",
+        value: 128,
+      },
+      {
         identifier: "☕",
         value: null,
       },


### PR DESCRIPTION
This pull request resolves #347 to expand the options of the doubling strategy to include 32, 64, and 128.

